### PR TITLE
add build_sweary() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,6 @@ Suggests:
     testthat,
     devtools,
     dplyr,
-    purrr
+    purrr,
+    rmarkdown
 Imports: glue

--- a/R/build_tools.R
+++ b/R/build_tools.R
@@ -4,6 +4,11 @@
 #'   by running a prepared script. It lists all language files
 #'   and constructs the data frame.
 #'
+#'   Then it rerenders the README.Rmd file so that all the proper
+#'   numbers of new words and languages propagate into README.md.
+#'   We also have to delete the README.html file that is created
+#'   in the process.
+#'
 #'   The next step is to create necesarry documentation from
 #'   roxygen comments.
 #'
@@ -22,6 +27,10 @@
 build_sweary <- function() {
 	# Rebuild a swear_words data frame
 	source("data-raw/swear-words.R")
+	# Rerender the README file
+	rmarkdown::render("README.Rmd", output_format = "github_document", encoding = "UTF-8")
+	# Unlink a temporary preview HTML file
+	unlink("README.html")
 	# Rebuild documentation
 	devtools::document(roclets = c("rd", "collate", "namespace"))
 	# Rebuild package

--- a/man/build_sweary.Rd
+++ b/man/build_sweary.Rd
@@ -11,6 +11,11 @@ It starts with rebuilding the `swear_words` data frame
   by running a prepared script. It lists all language files
   and constructs the data frame.
 
+  Then it rerenders the README.Rmd file so that all the proper
+  numbers of new words and languages propagate into README.md.
+  We also have to delete the README.html file that is created
+  in the process.
+
   The next step is to create necesarry documentation from
   roxygen comments.
 


### PR DESCRIPTION
Because we need to have local tests to see if the language files are OK, we need a custom build mechanism.

This PR adds an unexported build_sweary() function for development purposes. It does several steps before the build. Namely:

1. Rebuilds `swear_words` data frame with the newest added or modified language files.
2. Updates documentation.
3. Builds the package.
4. Runs local tests.
5. Runs a complex check including main tests in `tests/testthat` (empty for now).

This process should be used before any push. Only branches, PRs that pass this processed should be allowed to be merged into master.

Any suggestions, comments? @MarcinKosinski 